### PR TITLE
Silence zsh message

### DIFF
--- a/.profile
+++ b/.profile
@@ -4,3 +4,4 @@ chruby ruby-2.5.0
 
 alias bx='bundle exec'
 set -o vi
+export BASH_SILENCE_DEPRECATION_WARNING=1


### PR DESCRIPTION
Since upgrade to Catalina, the default shell is zsh not bash. I prefer to use bash but I also prefer not to have this message

```
The default interactive shell is now zsh.
To update your account to use zsh, please run `chsh -s /bin/zsh`.
For more details, please visit https://support.apple.com/kb/HT208050.
```

every time I open a terminal or tmux frame.

This silences it.